### PR TITLE
:art: Improve naming and documentation of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Configuration is done using environment variables:
 * `AMQP_USER`: RabbitMQ user
 * `AMQP_PASS`: RabbitMQ password
 * `AMQP_VHOST`: RabbitMQ virtual host, defaults to '/'
-* `GATEWAY_RESULT_QUEUE`: RabbitMQ where results will be posted
+* `GATEWAY_RESULT_QUEUE`: AMQP queue (inbound) to receive results
+* `GATEWAY_TASK_RK`: AMQP routing key (outbound) for requests to the [Canonizer](https://github.com/penguineer/cleanURI-canonizer)
 * `GATEWAY_CACHE_TIMEOUT`: Timeout for waiting on backend results (default: 30s)
 * `GATEWAY_CACHE_EVICT`: Cache eviction interval (default: 300s)
 

--- a/src/main/java/com/penguineering/cleanuri/apigateway/http/ReductionEndpoint.java
+++ b/src/main/java/com/penguineering/cleanuri/apigateway/http/ReductionEndpoint.java
@@ -28,8 +28,8 @@ public class ReductionEndpoint {
     @Inject
     ResultManager<ExtractionTask> resultMgr;
 
-    @Property(name = "gateway.amqp-task-queue")
-    String taskQueue;
+    @Property(name = "gateway.amqp-task-rk")
+    String taskRK;
 
     @Property(name = "gateway.amqp-result-queue")
     String resultQueue;
@@ -60,7 +60,7 @@ public class ReductionEndpoint {
         final ExtractionTask task = ExtractionTask.Builder.withRequest(requestBuilder.instance()).instance();
         final ExpectedResult<ExtractionTask> res = resultMgr.registerExpectation(timeout.toMillis());
 
-        emitter.send(taskQueue, res.getCorrelationId(), resultQueue, task);
+        emitter.send(taskRK, res.getCorrelationId(), resultQueue, task);
 
         return res.getCompletableFuture();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,4 @@ gateway:
   cache-timeout: ${GATEWAY_CACHE_TIMEOUT:30s}
   cache-evict: ${GATEWAY_CACHE_EVICT:300s}
   amqp-result-queue: ${GATEWAY_RESULT_QUEUE}
-  amqp-task-queue: ${GATEWAY_TASK_QUEUE}
+  amqp-task-rk: ${GATEWAY_TASK_RK}


### PR DESCRIPTION
The current naming scheme is not very clear on the AMQP endpoints (queues, routing keys) that are used and their respective purpose. This PR employs a (hopefully) clear naming scheme for easier configuration of the service.