### PR TITLE
:green_heart: Fix calls to the reusable workflows

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -20,4 +20,6 @@ jobs:
       - call-maven-test
     with:
       image: mrtux/cleanuri-apigateway
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Sending inherited secrets apparently only works in organisations and otherwise leads to an internal error. Explicitly state them to make the workflows work.