### PR TITLE
:arrow_up: Bump dependency cleanuri-common to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-common</artifactId>
-      <version>v0.2.0</version>
+      <version>0.4.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request includes an update to the `pom.xml` file to upgrade the version of the `cleanURI-common` dependency.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L122-R122): Updated the version of the `cleanURI-common` dependency from `v0.2.0` to `0.4.0`.