### PR TITLE
:arrow_up: Pin dependency logback-classic to 1.5.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>1.5.17</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file. The change specifies the version for the `logback-classic` dependency.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R102): Added version `1.5.17` for the `logback-classic` dependency.