### PR TITLE
Fix the groupId of the micronaut-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>io.micronaut.build</groupId>
+        <groupId>io.micronaut.maven</groupId>
         <artifactId>micronaut-maven-plugin</artifactId>
         <configuration>
           <configFile>aot-${packaging}.properties</configFile>


### PR DESCRIPTION
This is a regression from #28 which has not been caught by CI.

Fixes #29 